### PR TITLE
Mount the whole /run directory to container

### DIFF
--- a/helm-chart/templates/loggie-agent-daemonset.yaml
+++ b/helm-chart/templates/loggie-agent-daemonset.yaml
@@ -64,8 +64,9 @@ spec:
               name: docker
             {{- end }}
             {{- if eq .Values.config.loggie.discovery.kubernetes.containerRuntime "containerd" }}
-            - mountPath: /run/containerd/containerd.sock
-              name: containerdsocket
+            - mountPath: /run/
+              mountPropagation: HostToContainer
+              name: hostrun
             {{- end }}
             {{- end }}
 
@@ -103,9 +104,9 @@ spec:
         {{- end }}
         {{- if eq .Values.config.loggie.discovery.kubernetes.containerRuntime "containerd" }}
         - hostPath:
-            path: /run/containerd/containerd.sock
+            path: /run
             type: ""
-          name: containerdsocket
+          name: hostrun
         {{- end }}
         {{- end }}
 


### PR DESCRIPTION
When containerd's runtime is kata, we need to mount the /run directory to container

depend on: https://github.com/loggie-io/loggie/pull/554